### PR TITLE
fix: duplicate key value

### DIFF
--- a/ldap_config_freeipa.py
+++ b/ldap_config_freeipa.py
@@ -65,6 +65,8 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "last_name": "sn",
 }
 
+AUTH_LDAP_USER_QUERY_FIELD = "username"
+
 '''
 This search ought to return all groups to which the user belongs.
 django_auth_ldap uses this to determine group hierarchy. The string `netbox*` 


### PR DESCRIPTION
Add setting `AUTH_LDAP_USER_QUERY_FIELD = "username"` to prevent duplicated user message error.
Closes #5